### PR TITLE
Changes to the build process to include symbols

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -86,9 +86,8 @@ jobs:
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.AZURE_ARTIFACTS_PAT }}
 
-      - name: dotnet build and publish
+      - name: dotnet pack
         run: |
-          dotnet build --configuration Release ${{env.SOLUTION_FOLDER}}
           dotnet pack -c Release ${{env.SDK_FOLDER}}RTGS.DotNetSDK.csproj
 
       - name: 'dotnet publish'
@@ -108,9 +107,8 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
 
-      - name: dotnet build and publish
+      - name: dotnet pack
         run: |
-          dotnet build --configuration Release ${{env.SOLUTION_FOLDER}}
           dotnet pack -c Release ${{env.SDK_FOLDER}}RTGS.DotNetSDK.csproj
 
       - name: 'dotnet publish'

--- a/src/RTGS.DotNetSDK/RTGS.DotNetSDK/RTGS.DotNetSDK.csproj
+++ b/src/RTGS.DotNetSDK/RTGS.DotNetSDK/RTGS.DotNetSDK.csproj
@@ -11,7 +11,14 @@
 		<RootNamespace>RTGS.DotNetSDK</RootNamespace>
 		<PackageIcon>rtgs_global_logo.png</PackageIcon>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>		
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -19,6 +26,10 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 		<PackageReference Include="MinVer" Version="2.5.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This change produces a symbol pack so to aid in debugging. I have also removed two build commands that are not needed when using `dotnet pack`